### PR TITLE
Fix the template literal in the message service.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Angular Hello World
 
-This is an Angular hello world application that demonstrates data binding and RxJS observables. View a demo of the application at [https://trevorkarjanis.github.io/angular-hello-world](https://trevorkarjanis.github.io/angular-hello-world).
+This is an Angular hello world application that demonstrates data binding and RxJS observables. It includes debounced user input and a message service that recycles ongoing requests. View a demo of the application at [https://trevorkarjanis.github.io/angular-hello-world](https://trevorkarjanis.github.io/angular-hello-world).
 
 This project was built with [Angular](https://angular.io/) and [Angular CLI](https://github.com/angular/angular-cli) version 9.0.0-next.0.
 

--- a/src/app/message.service.ts
+++ b/src/app/message.service.ts
@@ -17,7 +17,7 @@ export class MessageService implements OnDestroy {
 
     get<R>(id: string): Observable<R> {
         if (this.requests[id]) return this.requests[id];
-        return this.requests[id] = this.http.get('resources/${id}').pipe(
+        return this.requests[id] = this.http.get(`resources/${id}`).pipe(
             takeUntil(this.destroy$),
             tap(_ => delete this.requests[id]),
             map(data => data as R),

--- a/src/app/message.service.ts
+++ b/src/app/message.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable, OnDestroy } from '@angular/core';
-import { Subject, Observable } from 'rxjs';
-import { takeUntil, tap, map, share } from 'rxjs/operators';
+import { Observable, Subject } from 'rxjs';
+import { finalize, map, share, takeUntil } from 'rxjs/operators';
 
 @Injectable()
 export class MessageService implements OnDestroy {
@@ -19,9 +19,9 @@ export class MessageService implements OnDestroy {
         if (this.requests[id]) return this.requests[id];
         return this.requests[id] = this.http.get(`resources/${id}`).pipe(
             takeUntil(this.destroy$),
-            tap(_ => delete this.requests[id]),
             map(data => data as R),
+            finalize(() => delete this.requests[id]),
             share()
-        )
+        );
     }
 }


### PR DESCRIPTION
- Replace the single quotes with tildes to fix the template literal in the message service.
- Use finalize to handle errors in the message service.
- Update the readme to elaborate on the examples.

Linted, built, and tested
- Verified that the application works correctly